### PR TITLE
Disable urwid mouse handling

### DIFF
--- a/microscope/ui/ui.py
+++ b/microscope/ui/ui.py
@@ -93,7 +93,7 @@ def ui(runner: MonitorRunner, empty_column_timeout: int):
             runner.data_queue.put({})
 
     mainloop = urwid.MainLoop(frame, palette, screen,
-                              unhandled_input=unhandled)
+                              unhandled_input=unhandled, handle_mouse=False)
 
     def wait_for_values(monitor_columns, queue, close_queue):
         while(close_queue.empty()):


### PR DESCRIPTION
This will enable user to copy output without pressing shift/fn

fixes #33 