### PR TITLE
Read-only microscope RBAC privileges for CEP and CNP

### DIFF
--- a/docs/microscope.yaml
+++ b/docs/microscope.yaml
@@ -38,7 +38,17 @@ rules:
   - ciliumnetworkpolicies
   - ciliumendpoints
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.ioa
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
We switched to using CEPs to get endpoint information, but granted read
and write permissions to microscope in RBAC enabled clusters. This
switches them to read-only.

Fixes #62 