### PR TITLE
Correct apiGroup permissions for pod

### DIFF
--- a/docs/microscope.yaml
+++ b/docs/microscope.yaml
@@ -42,7 +42,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking.k8s.ioa
+  - networking.k8s.io
   resources:
   - networkpolicies
   verbs:


### PR DESCRIPTION
This domain group was typoed, and this would cause issues when using microscope.