### PR TITLE
Support pip 10 pip._internal.req import path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@ import sys
 import uuid
 
 from setuptools import setup
-from pip.req import parse_requirements
+try:  # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError:  # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 version = "1.0.0"
 


### PR DESCRIPTION
pip 10 moved pip.req to pip._internal.req. This is used during installs
and it's better to support old and new versions.

Signed-off-by: Ray Bejjani <ray@covalent.io>