### PR TITLE
Add ip -> podname & endpoint id -> podname resolution

### DIFF
--- a/microscope/__main__.py
+++ b/microscope/__main__.py
@@ -22,6 +22,9 @@ def main():
     parser.add_argument('--hex', action='store_true', default=False)
     parser.add_argument('--resolve-pod-ips', action='store_true',
                         default=False, help='Resolve cluster IPs to podnames')
+    parser.add_argument('--resolve-endpoint-ids', action='store_true',
+                        default=False,
+                        help='Resolve cilium endpoint IDs to podnames')
 
     # taken from github.com/cilium/cilium/cmd/monitor.go
     type_choices = ['drop', 'debug', 'capture', 'trace', 'l7', 'agent']
@@ -111,7 +114,8 @@ def main():
     api = core_v1_api.CoreV1Api()
     runner = MonitorRunner(args.cilium_namespace, api, args.namespace)
 
-    monitor_args = MonitorArgs(args.verbose, args.hex, args.resolve_pod_ips,
+    monitor_args = MonitorArgs(args.verbose, args.hex,
+                               args.resolve_pod_ips, args.resolve_endpoint_ids,
                                args.selector, args.pod, args.endpoint,
                                args.to_selector, args.to_pod,
                                args.to_endpoint, args.from_selector,

--- a/microscope/__main__.py
+++ b/microscope/__main__.py
@@ -20,6 +20,8 @@ def main():
                         'Will not work on last monitor on screen.')
     parser.add_argument('--verbose', action='store_true', default=False)
     parser.add_argument('--hex', action='store_true', default=False)
+    parser.add_argument('--resolve-pod-ips', action='store_true',
+                        default=False, help='Resolve cluster IPs to podnames')
 
     # taken from github.com/cilium/cilium/cmd/monitor.go
     type_choices = ['drop', 'debug', 'capture', 'trace', 'l7', 'agent']
@@ -109,8 +111,9 @@ def main():
     api = core_v1_api.CoreV1Api()
     runner = MonitorRunner(args.cilium_namespace, api, args.namespace)
 
-    monitor_args = MonitorArgs(args.verbose, args.hex, args.selector, args.pod,
-                               args.endpoint, args.to_selector, args.to_pod,
+    monitor_args = MonitorArgs(args.verbose, args.hex, args.resolve_pod_ips,
+                               args.selector, args.pod, args.endpoint,
+                               args.to_selector, args.to_pod,
                                args.to_endpoint, args.from_selector,
                                args.from_pod, args.from_endpoint, args.type,
                                args.namespace)

--- a/microscope/monitor/epresolver.py
+++ b/microscope/monitor/epresolver.py
@@ -1,0 +1,43 @@
+import re
+
+from typing import Dict
+
+
+def substitute(matcher, lookup, text):
+    """Substitute matched fields in text by looking them up, then return it"""
+    if matcher is None:
+        return text
+    # When the matcher regex matches a field, look up the substitution in
+    # lookup
+    return matcher.sub(lambda m: lookup[m.string[m.start():m.end()]], text)
+
+
+class EndpointResolver:
+    """EndpointResolver resolves various fields to the pod-name
+
+    resolve_ips: convert IPs belonging to an endpoint to the podname
+    endpoint_data: a list of lists of endpoint objects obtained from
+                   cilium-agent or k8s CEPs
+    """
+    def __init__(self, resolve_ips: bool, endpoint_data: [Dict]):
+        self.ip_resolutions = {}
+        self.epid_resolutions = {}
+        self.ip_resolutions_regex = None
+        self.epid_resolutions_regex = None
+
+        if resolve_ips:  # if false, use the empty dict above that does no work
+            for epdata in endpoint_data:
+                for ep in epdata:
+                    podname = ep['status']['external-identifiers']['pod-name']
+                    for ip in ep['status']['networking']['addressing']:
+                        self.ip_resolutions[ip['ipv4']] = podname
+                        self.ip_resolutions[ip['ipv6']] = podname
+            self.ip_resolutions_regex = \
+                re.compile("(%s)" %
+                    "|".join(map(re.escape,
+                        self.ip_resolutions.keys())))
+
+    def resolve_to_podnames(self, line):
+        """replace fields in line with the podname, if configured"""
+        line = substitute(self.ip_resolutions_regex, self.ip_resolutions, line)
+        return line

--- a/microscope/monitor/monitor.py
+++ b/microscope/monitor/monitor.py
@@ -1,4 +1,4 @@
-from typing import List,Dict
+from typing import List
 import signal
 import threading
 from multiprocessing import Process, Queue


### PR DESCRIPTION
_This PR should only be merged after https://github.com/cilium/microscope/pull/68_

This is a half-attempt to accomodate https://github.com/cilium/cilium/issues/3889. We can build on this for https://github.com/cilium/cilium/issues/3888 as well, if we feel it's worth continuing with this.
The code is messy, and I'm not sure if I've kept with our conventions. Note that I included the pip 10 support commit (separately in a PR in https://github.com/cilium/microscope/pull/68) to get this to work on my env.

I chose to print podnames since, even on my minikube cluster running just microscope, the label list is longer than the log lines we're printing. The podname should be reasonably useful, globally unique, and the user may derive the labels separately if needed.


```minikube: -> endpoint kube-system:microscope flow 0x4f8da08 identity 1->43758 state reply ifindex lxc93a5c: 10.96.0.1:443 -> kube-system:microscope:47970 tcp ACK```
