### PR TITLE
Filter monitor events by ips

### DIFF
--- a/microscope/__main__.py
+++ b/microscope/__main__.py
@@ -43,6 +43,8 @@ def main():
                         'Can specify multiple.')
     parser.add_argument('--endpoint', action='append', type=int, default=[],
                         help='Cilium endpoint ids. Can specify multiple.')
+    parser.add_argument('--ip', action='append', default=[],
+                        help='K8s pod ips. Can specify multiple.')
 
     parser.add_argument('--to-selector', action='append', default=[],
                         help='k8s equality label selectors for pods which '
@@ -60,6 +62,8 @@ def main():
                         help='Cilium endpoint ids. '
                         'Matches events that go to specified endpoints. '
                         'Can specify multiple.')
+    parser.add_argument('--to-ip', action='append', default=[],
+                        help='K8s pod ips. Can specify multiple.')
 
     parser.add_argument('--from-selector', action='append', default=[],
                         help='k8s equality label selectors for pods which '
@@ -78,6 +82,8 @@ def main():
                         help='Cilium endpoint ids. '
                         'Matches events that come from specified endpoints. '
                         'Can specify multiple.')
+    parser.add_argument('--from-ip', action='append', default=[],
+                        help='K8s pod ips. Can specify multiple.')
 
     parser.add_argument('--send-command', type=str, default="",
                         help='Execute command as-provided in argument on '
@@ -117,7 +123,8 @@ def main():
                                args.to_selector, args.to_pod,
                                args.to_endpoint, args.from_selector,
                                args.from_pod, args.from_endpoint, args.type,
-                               args.namespace, args.raw)
+                               args.namespace, args.raw,
+                               args.ip, args.to_ip, args.from_ip)
 
     def handle_signals(_, __):
         runner.finish()

--- a/microscope/monitor/test_monitor.py
+++ b/microscope/monitor/test_monitor.py
@@ -3,6 +3,7 @@ from microscope.monitor.parser import MonitorOutputProcessorSimple
 from microscope.monitor.parser import MonitorOutputProcessorVerbose
 from microscope.monitor.parser import MonitorOutputProcessorJSON
 from microscope.monitor.epresolver import EndpointResolver
+from microscope.monitor.runner import MonitorRunner
 
 
 def test_non_verbose_mode():
@@ -297,3 +298,14 @@ def test_json_processor():
         "Policy updated: {'labels': ['unspec:io.cilium.k8s.policy.name=rule1', 'unspec:io.cilium.k8s.policy.namespace=default'], 'revision': 10, 'rule_count': 1}"  # noqa: E501
 
     )
+
+
+def test_runner_retrieve_ep_ids():
+    runner = MonitorRunner(None, None, None)
+
+    ids = runner.retrieve_endpoint_ids(
+        test_endpoints, [], [],
+        ["10.0.0.1", "f00d::a0f:0:0:1687"], "default")
+
+    assert 5766 in ids
+    assert 30391 in ids


### PR DESCRIPTION
`--ip`, `--to-ip` and `--from-ip` flags are added.
Endpoints are chosen based on endpoint data retrieved from Cilium
Endpoint CRD.