### PR TITLE
docs: made small changes in k8s spec.yaml

### DIFF
--- a/docs/microscope.yaml
+++ b/docs/microscope.yaml
@@ -70,5 +70,5 @@ spec:
     - sleep
     - "100000"
     image: cilium/microscope:1.0.1
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     name: microscope

--- a/docs/microscope.yaml
+++ b/docs/microscope.yaml
@@ -69,6 +69,6 @@ spec:
   - args:
     - sleep
     - "100000"
-    image: cilium/microscope:1.0.1
+    image: docker.io/cilium/microscope:1.0.1
     imagePullPolicy: IfNotPresent
     name: microscope


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

@nebril can we change the version used in the yaml file to `v1.0.1`. It is the same way we use in the cilium/cilium versioning. `1.0.1` can still exist  in docker hub for existing users that use the old `docs/microscope.yaml`