### PR TITLE
Using get method to avoid exception.

### DIFF
--- a/microscope/monitor/runner.py
+++ b/microscope/monitor/runner.py
@@ -202,7 +202,8 @@ class MonitorRunner:
         crds = client.CustomObjectsApi()
         cep_resp = crds.list_cluster_custom_object("cilium.io", "v2",
                                                    "ciliumendpoints")
-        return [e['status'] for e in cep_resp['items']]
+        return [e.get('status') for e in cep_resp['items'] if
+                e.get('status') is not None]
 
     def get_node_endpoint_data(self, node: str):
         exec_command = ['cilium', 'endpoint', 'list', '-o', 'json']


### PR DESCRIPTION
Found the following problem in the Microscope runs in CI, the following
error will prevent to return an error in case that the status was not
present.

```
/usr/src/microscope # microscope | ts
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/bin/microscope/__main__.py", line 153, in <module>
  File "/bin/microscope/__main__.py", line 138, in main
  File "/bin/microscope/microscope/monitor/runner.py", line 98, in run
  File "/bin/microscope/microscope/monitor/runner.py", line 205, in retrieve_endpoint_data
  File "/bin/microscope/microscope/monitor/runner.py", line 205, in <listcomp>
KeyError: 'status'
Jul 24 14:33:34
Jul 24 14:33:34 closing
/usr/src/microscope #

```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>